### PR TITLE
docs: Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Documentation: https://firstbober.github.io/wapanel
 ## Maintaining
 I will be trying to fix incoming issues in issue tracker but not add new features, if you want some upstream then pull request are open.
 
+## Packaging status
+
+### Fedora
+
+Available in official [repo](https://src.fedoraproject.org/rpms/wapanel).
+
+```
+sudo dnf install wapanel
+```
+
 ## Building
 ### Dependencies
 - Meson *


### PR DESCRIPTION
`wapanel` packaged for official Fedora repos and now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2021-48911c36cb). Would be nice to mention this in docs. Thanks!