### PR TITLE
Add missing gio-unix-2.0 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,11 +12,11 @@ pkgconfig      = import('pkgconfig')
 gtklayershell  = dependency('gtk-layer-shell-0', version: '>= 0.6', fallback: ['gtk-layer-shell', 'gtk_layer_shell'])
 gtk3           = dependency('gtk+-3.0')
 gio2           = dependency('gio-2.0')
+gio2unix       = dependency('gio-unix-2.0')
 
 deps = [
 	gtk3,
 	gio2,
-
 	gtklayershell,
 	dynlink
 ]

--- a/src/applets/app-finder/meson.build
+++ b/src/applets/app-finder/meson.build
@@ -12,6 +12,7 @@ library('wapanel-applet-app-finder',
 	],
 	dependencies: [
 		gtk3,
+		gio2unix,
 		dependency('threads'),
 		gtklayershell
 	],

--- a/src/applets/task-switcher/meson.build
+++ b/src/applets/task-switcher/meson.build
@@ -52,6 +52,7 @@ library('wapanel-applet-task-switcher',
 	dependencies: [
 		gtk3,
 		gio2,
+		gio2unix,
 		wl_protos
 	],
 	install: true,


### PR DESCRIPTION
The Linux distribution that I use complains if `gio-unix-2.0` is not added as a dependency.