### PR TITLE
README.md: Add step to load git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Asterisk indicates compile-time dependencies.
 ### Cloning
 ```sh
 git clone --recurse-submodules https://github.com/Firstbober/wapanel.git
+git submodule update --init --recursive
 ```
 
 ### Compiling and installation


### PR DESCRIPTION
Otherwise toml.hpp might be missing

I got the following while trying to build wapanel:

```
#:~/git/wapanel/build$ sudo ninja install
[1/7] Compiling C++ object wapanel.p/src_wap_t_convert.cc.o
FAILED: wapanel.p/src_wap_t_convert.cc.o 
c++ -Iwapanel.p -I. -I.. -I../thirdparty/toml11 -I../thirdparty/xdgpp -Isubprojects/gtk-layer-shell/include -I../subprojects/gtk-layer-shell/include -I/usr/include/gtk-3.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/gio-unix-2.0 -I/usr/include/cairo -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/harfbuzz -I/usr/include/atk-1.0 -I/usr/include/pixman-1 -I/usr/include/uuid -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++2a -g -pthread -MD -MQ wapanel.p/src_wap_t_convert.cc.o -MF wapanel.p/src_wap_t_convert.cc.o.d -o wapanel.p/src_wap_t_convert.cc.o -c ../src/wap_t_convert.cc
In file included from ../src/wap_t_convert.cc:1:
../src/wap_t_convert.hh:4:10: fatal error: toml.hpp: Datei oder Verzeichnis nicht gefunden
    4 | #include <toml.hpp>
      |          ^~~~~~~~~~
compilation terminated.
```
.. after updating submodules, that is fixed.